### PR TITLE
Small fixes for the progress bar

### DIFF
--- a/src/progress.c
+++ b/src/progress.c
@@ -87,12 +87,12 @@ progress_bar *progress_bar_new(long resume_from)
 
   /* Try to grab the COLUMNS environment variable to initialize pb->with with a suitable value. */
   environ = g_get_environ();
-  g_environ_getenv(environ, "COLUMNS");
+  columns = g_environ_getenv(environ, "COLUMNS");
 
   if (columns) {
     char *endptr;
     long num = strtol(columns, &endptr, 10);
-    if ((endptr != columns) && (endptr == columns + g_strlen(columns)) && (num > 0)) {
+    if ((endptr != columns) && (endptr == columns + strlen(columns)) && (num > 0)) {
       pb->width = MIN(pb->width, (int)num); /* restrict width of progress bar to avoid insane values */
     }
   }

--- a/src/progress.h
+++ b/src/progress.h
@@ -29,7 +29,7 @@ typedef struct _progress_bar {
 } progress_bar;
 
 progress_bar *progress_bar_new(long resume_from);
-void progress_bar_end(progress_bar *pb);
+void progress_bar_free(progress_bar *pb);
 int progress_bar_cb(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow);
 
 #endif /* PROGRESS_H */


### PR DESCRIPTION
At first I had trouble compiling castget, since the build system wasn't able to find `g_strlen()`. AFAICT, there is no function named `g_strlen()` in glib.