### PR TITLE
Add rudimentary test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ configure
 depcomp
 install-sh
 libtool
+test-driver
 ltmain.sh
 Makefile
 Makefile.in
@@ -21,4 +22,6 @@ po
 src/.deps
 src/.libs
 src/*.o
+tests/*.o
 src/castget
+test-suite.log

--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,11 @@ config.status
 config.sub
 aclocal.m4
 po
-src/.deps
-src/.libs
-src/*.o
-tests/*.o
+.libs
+*.deps
+*.o
+*.log
+*.trs
+*.dirstamp
 src/castget
-test-suite.log
+tests/test_progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ addons:
       - libid3-3.8.3-dev
       - libcurl4-gnutls-dev
 
-script: ./autogen.sh --disable-id3lib && make all && make clean
+script: ./autogen.sh --disable-id3lib && make all && make check && make clean

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@
 #
 AC_PREREQ(2.59)
 AC_INIT(castget, 1.2.3, mariuslj@ifi.uio.no)
-AM_INIT_AUTOMAKE([1.8 dist-bzip2 no-dist-gzip])
+AM_INIT_AUTOMAKE([1.8 dist-bzip2 no-dist-gzip foreign])
 AC_CONFIG_SRCDIR([src/castget.c])
 AC_CONFIG_HEADER([config.h])
 
@@ -93,5 +93,6 @@ AC_CHECK_FUNCS([strdup strtol])
 AC_CONFIG_FILES([
   Makefile
   src/Makefile
+  tests/Makefile
 ])
 AC_OUTPUT

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2005-2017 Marius L. Jøhndal
+# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013 Marius L. Jøhndal
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -15,29 +15,14 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-SUBDIRS = tests src
+INCLUDES = $(GLIBS_CFLAGS) $(CURL_CFLAGS)
 
-EXTRA_DIST = \
-  castgetrc.example \
-  castget.1.ronn \
-  castgetrc.5.ronn \
-  CHANGES \
-  ChangeLog.old \
-  NEWS.old
+AUTOMAKE_OPTIONS = subdir-objects
 
-man_MANS = \
-  castget.1 \
-  castgetrc.5
+TESTS = test_progress
 
-.PHONY: html AUTHORS
+bin_PROGRAMS = test_progress
 
-html: castget.1.html castgetrc.5.html
+test_progress_SOURCES = test_progress.c ../src/progress.c ../src/progress.h
 
-AUTHORS:
-	git shortlog -sn | cut -c8- | grep -v Bitdeli > $@
-
-%.html: %.ronn
-	ronn --manual="User Commands" --organization="castget @VERSION@" --html $< > $@
-
-%: %.ronn
-	ronn --manual="User Commands" --organization="castget @VERSION@" --roff $< > $@
+test_progress_LDADD = $(GLIBS_LIBS) $(CURL_LIBS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013 Marius L. Jøhndal
+# Copyright (C) 2017 Wilhelm Schuster
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/test_progress.c
+++ b/tests/test_progress.c
@@ -1,0 +1,74 @@
+#include <glib.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "../src/progress.h"
+
+static void
+test_progress_bar_new()
+{
+  char *old_columns = getenv("COLUMNS");
+  progress_bar *pb;
+
+  setenv("COLUMNS", "120", 1);
+  pb = progress_bar_new(0);
+  g_assert_cmpint(pb->width, ==, 74);
+  progress_bar_free(pb);
+
+  setenv("COLUMNS", "50", 1);
+  pb = progress_bar_new(0);
+  g_assert_cmpint(pb->width, ==, 45);
+  progress_bar_free(pb);
+
+  setenv("COLUMNS", "abc", 1);
+  pb = progress_bar_new(0);
+  g_assert_cmpint(pb->width, ==, 74);
+  progress_bar_free(pb);
+
+  if (old_columns) {
+    setenv("COLUMNS", old_columns, 1);
+  }
+}
+
+static void
+test_progress_bar_cb()
+{
+  char *old_columns = getenv("COLUMNS");
+  progress_bar *pb;
+
+  setenv("COLUMNS", "78", 1);
+  pb = progress_bar_new(0);
+  /* Silence progress bar output by directing it to a temporary file */
+  pb->f = tmpfile();
+
+  progress_bar_cb(pb, 300, 0, 0, 0);
+  g_assert_cmpstr(pb->buffer, ==, "                                                                         ");
+  progress_bar_cb(pb, 300, 150, 0, 0);
+  g_assert_cmpstr(pb->buffer, ==, "####################################                                     ");
+  progress_bar_cb(pb, 300, 450, 0, 0);
+  g_assert_cmpstr(pb->buffer, ==, "#########################################################################");
+  progress_bar_cb(pb, 300, -1, 0, 0);
+  g_assert_cmpstr(pb->buffer, ==, "                                                                         ");
+  pb->resume_from = 150;
+  progress_bar_cb(pb, 150, 0, 0, 0);
+  g_assert_cmpstr(pb->buffer, ==, "####################################                                     ");
+
+  fclose(pb->f);
+  progress_bar_free(pb);
+
+  if (old_columns) {
+    setenv("COLUMNS", old_columns, 1);
+  }
+}
+
+
+int
+main (int   argc, char *argv[])
+{
+  g_test_init(&argc, &argv, NULL);
+
+  g_test_add_func("/progress/progress_bar_new", test_progress_bar_new);
+  g_test_add_func("/progress/progress_bar_cp", test_progress_bar_cb);
+
+  return g_test_run();
+}


### PR DESCRIPTION
Add a small test suite using glib's testing primitives. This should help integrating regression tests later down the road to ensure compatibility weird feeds and other oddities.