### PR TITLE
Enable libcurl’s compression support

### DIFF
--- a/src/urlget.c
+++ b/src/urlget.c
@@ -56,6 +56,7 @@ int urlget_buffer(const char *url, void *user_data,
     curl_easy_setopt(easyhandle, CURLOPT_WRITEDATA, user_data);
     curl_easy_setopt(easyhandle, CURLOPT_FOLLOWLOCATION, 1);
     curl_easy_setopt(easyhandle, CURLOPT_USERAGENT, user_agent);
+    curl_easy_setopt(easyhandle, CURLOPT_ACCEPT_ENCODING, "");
 
     if (pb) {
       curl_easy_setopt(easyhandle, CURLOPT_NOPROGRESS, 0);


### PR DESCRIPTION
Firstly, thanks for `castget`.  It is great!

Less importantly, this commit enables support for compression.  Many of the feeds I subscribe to are very large, and this simple change drops network transfers by around 80%.  Obviously your mileage will vary, but it should help in most situations.

Thanks,

James