### PR TITLE
Support setting media tags for podcasts with enclosure type "audio/mp3"

### DIFF
--- a/src/castget.c
+++ b/src/castget.c
@@ -266,7 +266,7 @@ static void update_callback(void *user_data, channel_action action,
     g_assert(filename);
 
     /* Set media tags. */
-    if (enclosure->type && !strcmp(enclosure->type, "audio/mpeg")) {
+    if (enclosure->type && (!strcmp(enclosure->type, "audio/mpeg") || !strcmp(enclosure->type, "audio/mp3"))) {
 #ifdef ENABLE_ID3LIB
       if (_id3_check_and_set(filename, c))
         fprintf(stderr, "Error setting ID3 tag for file %s.\n", filename);


### PR DESCRIPTION
I noticed that castget does not set the id3 tags for the "Bug Report" podcast. The reason is, that the podcast uses "audio/mp3" instead of "audio/mpeg" as its enclosure type. 

Snippet from https://bugreport.co.uk/bug_report_mp3.rss
```xml
<enclosure url="http://bugreport.co.uk/assets/bugreport_s1e10.mp3" length="60943241" type="audio/mp3"/>
```
My castgetrc file
```
[bugreport]
url=https://bugreport.co.uk/bug_report_mp3.rss
spool=/podcasts
id3leadartist=Bug Report Podcast
id3album=Bug Report Podcast
```