### PR TITLE
Add global setting for channel directory

### DIFF
--- a/src/castget.c
+++ b/src/castget.c
@@ -148,15 +148,8 @@ int main(int argc, char **argv)
 
   LIBXML_TEST_VERSION;
 
-  /* Build the channel directory path and ensure that it exists. */
+  /* Assigning default channel directory before reading configuration file */
   channeldir = g_build_filename(g_get_home_dir(), ".castget", NULL);
-
-  if (!g_file_test(channeldir, G_FILE_TEST_IS_DIR)) {
-    if (g_mkdir(channeldir, 0755) < 0) {
-      perror("Error creating channel directory");
-      return 1;
-    }
-  }
 
   /* Try opening configuration file. */
   if (!rcfile)
@@ -173,8 +166,20 @@ int main(int argc, char **argv)
         return -1;
 
       defaults = channel_configuration_new(kf, "*", NULL);
+
+      /* Read global channel directory setting from configuration */
+      if (defaults->channel_directory)
+        channeldir = defaults->channel_directory;
     } else
       defaults = NULL;
+
+    /* Build the channel directory path and ensure that it exists. */
+    if (!g_file_test(channeldir, G_FILE_TEST_IS_DIR)) {
+      if (g_mkdir_with_parents(channeldir, 0755) < 0) {
+        perror("Error creating channel directory");
+        return 1;
+      }
+    }
 
     /* Perform actions. */
     if (optind < argc) {

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -48,6 +48,9 @@ void channel_configuration_free(struct channel_configuration *c)
   if (c->spool_directory)
     g_free(c->spool_directory);
 
+  if (c->channel_directory)
+    g_free(c->regex_filter);
+
   if (c->filename_pattern)
     g_free(c->filename_pattern);
 
@@ -96,6 +99,7 @@ struct channel_configuration *channel_configuration_new(GKeyFile *kf, const gcha
   /* Read keys from configuration file. */
   c->url = _read_channel_configuration_key(kf, identifier, "url");
   c->spool_directory = _read_channel_configuration_key(kf, identifier, "spool");
+  c->channel_directory = _read_channel_configuration_key(kf, identifier, "channel");
   c->filename_pattern = _read_channel_configuration_key(kf, identifier, "filename");
   c->playlist = _read_channel_configuration_key(kf, identifier, "playlist");
   c->id3_lead_artist = _read_channel_configuration_key(kf, identifier, "id3leadartist");
@@ -114,6 +118,9 @@ struct channel_configuration *channel_configuration_new(GKeyFile *kf, const gcha
 
     if (!c->spool_directory && defaults->spool_directory)
       c->spool_directory = g_strdup(defaults->spool_directory);
+
+    if (!c->channel_directory && defaults->channel_directory)
+      c->channel_directory = g_strdup(defaults->channel_directory);
 
     if (!c->filename_pattern && defaults->filename_pattern)
       c->filename_pattern = g_strdup(defaults->filename_pattern);
@@ -165,6 +172,7 @@ int channel_configuration_verify_keys(GKeyFile *kf, const char *identifier)
   for (i = 0; key_list[i]; i++) {
     if (! (!strcmp(key_list[i], "url") ||
            !strcmp(key_list[i], "spool") ||
+           !strcmp(key_list[i], "channel") ||
            !strcmp(key_list[i], "filename") ||
            !strcmp(key_list[i], "playlist") ||
            !strcmp(key_list[i], "id3leadartist") ||

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -26,6 +26,7 @@ struct channel_configuration {
   gchar *identifier;
   gchar *url;
   gchar *spool_directory;
+  gchar *channel_directory;
   gchar *filename_pattern;
   gchar *playlist;
   gchar *id3_lead_artist;


### PR DESCRIPTION
I'd rather not have a ~/.castget folder if I can avoid it.
Channel directory can now be changed with:
channel=/home/user/.config/castget/channels

For now the setting is just named "channel" to follow the other settings syntax i.e spool -> spool_directory.