### PR TITLE
[feat][CI] Update clang-format-action version

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -7,4 +7,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C programs.
-      uses: jidicula/clang-format-action@master
+      uses: jidicula/clang-format-action@v2.0.0


### PR DESCRIPTION
Related to jidicula/clang-format-action#18

**Why this change was necessary**
The `master` branch of `clang-format-action` is set to be deleted
on January 15, so pointing to it may cause some problems.

**What this change does**
Updates the CI style workflow to point to a version of
`clang-format-action` pointing to the `main` branch.

**Any side-effects?**
None

**Additional context/notes/links**
 - https://github.com/jidicula/clang-format-action/releases/tag/v2.0.0