### PR TITLE
Fix issue #55: make the --debug flag take effect, which previously did nothing

### DIFF
--- a/src/castget.c
+++ b/src/castget.c
@@ -58,7 +58,6 @@ static gboolean resume = FALSE;
 static gboolean debug = FALSE;
 static gboolean show_progress_bar = FALSE;
 static gboolean show_version = FALSE;
-static gboolean show_debug_info = FALSE;
 static gboolean new_only = FALSE;
 static gboolean list = FALSE;
 static gboolean catchup = FALSE;
@@ -91,7 +90,7 @@ int main(int argc, char **argv)
     { "rcfile", 'C', 0, G_OPTION_ARG_FILENAME, &rcfile,
       "override the default configuration file name" },
 
-    { "debug", 'd', 0, G_OPTION_ARG_NONE, &show_debug_info,
+    { "debug", 'd', 0, G_OPTION_ARG_NONE, &debug,
       "print connection debug information" },
     { "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,
       "print detailed progress information" },


### PR DESCRIPTION
Solve issue https://github.com/mlj/castget/issues/55

The `--debug` flag was writing into a variable called `show_debug_info`, which was read nowhere. This changes it to write into the existing `debug` variable, which is used all over the place.

Manually tested that `--debug` now results in verbose CURL HTTP transaction logs being printed.