### PR TITLE
Misc improvements

### DIFF
--- a/castget.1.ronn
+++ b/castget.1.ronn
@@ -52,6 +52,9 @@ options as arguments.
 
 ### Global options
 
+  * `-R`, `--reverse`:
+    Reverse the order in which items in feeds are processed.
+
   * `-r`, `--resume`:
     Resume aborted downloads. Make sure not to use this option if the RSS feed uses the same filename for multiple enclosures as this will corrupt existing downloads.
 

--- a/castget.1.ronn
+++ b/castget.1.ronn
@@ -44,8 +44,11 @@ options as arguments.
     configuration file will not be considered as 'new' if it is added to the
     configuration again at a later time.
 
+  * `-s` <count>, `--stop-after`=<count>:
+    Stop after <count> items are processed.  This is implemented per-channel.
+
   * `-1`, `--first-only`:
-    Restrict operation to the most recent item in each channel only.
+    Restrict operation to the most recent item in each channel only.  Equivalent to --stop-after=1.
 
   * `-f` <pattern>, `--filter`=<pattern>:
     Restrict operation to enclosures whose download URLs match the regular expression `pattern`. Note that this will override any regular expression filters given in the configuration file.

--- a/castget.1.ronn
+++ b/castget.1.ronn
@@ -47,8 +47,14 @@ options as arguments.
   * `-s` <count>, `--stop-after`=<count>:
     Stop after <count> items are processed.  This is implemented per-channel.
 
+  * `-x`, `--count-disregards-eligibility`:
+    By default, `--stop-after` only counts items that castget considers eligible for processing (e.g. matches filters and has not been previously downloaded (or marked as downloaded with `--catchup`)).  This option modifies `--stop-after` so that the count applies to all items seen, regardless of whether the item was eligible for processing.
+
   * `-1`, `--first-only`:
-    Restrict operation to the most recent item in each channel only.  Equivalent to --stop-after=1.
+    Restrict operation to the most recent item in each channel only.  Equivalent to `--stop-after=1`.
+
+  * `-o`, `--first-only-disregards-eligibility`:
+    Stop processing when one item has been seen regardless of item's eligibility for processing.  Equivalent to `--stop-after=1 --count-disregards-eligibility`.
 
   * `-f` <pattern>, `--filter`=<pattern>:
     Restrict operation to enclosures whose download URLs match the regular expression `pattern`. Note that this will override any regular expression filters given in the configuration file.

--- a/configure.ac
+++ b/configure.ac
@@ -46,8 +46,8 @@ else
   AC_SUBST(CURL_LIBS)
 fi
 
-#AC_ARG_WITH(taglib, [  --without-taglib        disable taglib support])
-AC_ARG_WITH(taglib, AC_HELP_STRING([--without-taglib], [disable taglib support])])
+#AC_ARG_WITH(taglib, [  --without-taglib        disable taglib support)
+AC_ARG_WITH(taglib, AC_HELP_STRING([--without-taglib], [disable taglib support]))
 if test "x$with_taglib" != "xno"; then
   PKG_CHECK_MODULES(TAGLIB, [taglib_c])
   AC_SUBST(TAGLIB_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,11 @@ else
   AC_SUBST(CURL_LIBS)
 fi
 
+AC_PATH_PROG(RONN, ronn, no)
+if test "$RONN" = "no" ; then
+  AC_MSG_ERROR(Required tool ronn not found)
+fi
+
 #AC_ARG_WITH(taglib, [  --without-taglib        disable taglib support)
 AC_ARG_WITH(taglib, AC_HELP_STRING([--without-taglib], [disable taglib support]))
 if test "x$with_taglib" != "xno"; then

--- a/src/castget.c
+++ b/src/castget.c
@@ -71,6 +71,7 @@ int main(int argc, char **argv)
   static gboolean first_only = FALSE;
   static gboolean resume = FALSE;
   static gboolean debug = FALSE;
+  static gboolean reverse = FALSE;
   static gboolean show_progress_bar = FALSE;
   static gchar *rcfile = NULL;
   static gchar *filter_regex = NULL;
@@ -103,6 +104,8 @@ int main(int argc, char **argv)
     { "quiet", 'q', 0, G_OPTION_ARG_NONE, &quiet, "only print error messages" },
     { "first-only", '1', 0, G_OPTION_ARG_NONE, &first_only,
       "only process the most recent item from each channel" },
+    { "reverse", 'R', 0, G_OPTION_ARG_NONE, &reverse,
+      "process the channel in reverse order" },
     { "filter", 'f', 0, G_OPTION_ARG_STRING, &filter_regex,
       "only process items whose enclosure names match a regular expression" },
 
@@ -143,6 +146,7 @@ int main(int argc, char **argv)
   opts->first_only = first_only;
   opts->resume = resume;
   opts->debug = debug;
+  opts->reverse = reverse;
   opts->show_progress_bar = show_progress_bar;
 
   if (catchup) {

--- a/src/castget.c
+++ b/src/castget.c
@@ -69,7 +69,9 @@ int main(int argc, char **argv)
   GError *error = NULL;
   GOptionContext *context;
   static gboolean first_only = FALSE;
+  static gboolean first_only_disregard_eligibility = FALSE;
   static gint stop_after_count = 0;
+  static gboolean count_disregards_eligibility = FALSE;
   static gboolean resume = FALSE;
   static gboolean debug = FALSE;
   static gboolean reverse = FALSE;
@@ -105,7 +107,11 @@ int main(int argc, char **argv)
     { "quiet", 'q', 0, G_OPTION_ARG_NONE, &quiet, "only print error messages" },
     { "stop-after", 's', 0, G_OPTION_ARG_INT, &stop_after_count,
       "stop after processing ARGUMENT items from each channel" },
+    { "count-disregards-eligibility", 'x', 0, G_OPTION_ARG_NONE, &count_disregards_eligibility,
+      "when processing --stop-after, count considers all items, not just those eligible" },
     { "first-only", '1', 0, G_OPTION_ARG_NONE, &first_only,
+      "only process the most recent item from each channel" },
+    { "first-only-disregard-eligibility", 'c', 0, G_OPTION_ARG_NONE, &first_only_disregard_eligibility,
       "only process the most recent item from each channel" },
     { "reverse", 'R', 0, G_OPTION_ARG_NONE, &reverse,
       "process the channel in reverse order" },
@@ -145,8 +151,21 @@ int main(int argc, char **argv)
     g_print("--stop-after and --first-only are incompatible\n");
     exit(1);
   }
+  if (first_only_disregard_eligibility && stop_after_count) {
+    g_print("--stop-after and --first-only-disregard-eligibility are incompatible\n");
+    exit(1);
+  }
+  if (first_only_disregard_eligibility && first_only) {
+    g_print("--first-only and --first-only-disregard-eligibility are incompatible\n");
+    exit(1);
+  }
+
   if (first_only)
     stop_after_count = 1;
+  if (first_only_disregard_eligibility) {
+    stop_after_count = 1;
+    count_disregards_eligibility = TRUE;
+  }
 
   /* Decide on the action to take */
   if (show_version) {
@@ -158,6 +177,7 @@ int main(int argc, char **argv)
   opts->no_download = 0;
   opts->no_mark_read = 0;
   opts->stop_after_count = stop_after_count;
+  opts->count_disregards_eligibility = count_disregards_eligibility;
   opts->resume = resume;
   opts->debug = debug;
   opts->reverse = reverse;

--- a/src/castget.c
+++ b/src/castget.c
@@ -69,6 +69,7 @@ int main(int argc, char **argv)
   GError *error = NULL;
   GOptionContext *context;
   static gboolean first_only = FALSE;
+  static gint stop_after_count = 0;
   static gboolean resume = FALSE;
   static gboolean debug = FALSE;
   static gboolean reverse = FALSE;
@@ -102,6 +103,8 @@ int main(int argc, char **argv)
     { "new-only", 'n', 0, G_OPTION_ARG_NONE, &new_only,
       "only process new channels" },
     { "quiet", 'q', 0, G_OPTION_ARG_NONE, &quiet, "only print error messages" },
+    { "stop-after", 's', 0, G_OPTION_ARG_INT, &stop_after_count,
+      "stop after processing ARGUMENT items from each channel" },
     { "first-only", '1', 0, G_OPTION_ARG_NONE, &first_only,
       "only process the most recent item from each channel" },
     { "reverse", 'R', 0, G_OPTION_ARG_NONE, &reverse,
@@ -134,6 +137,17 @@ int main(int argc, char **argv)
     exit(1);
   }
 
+  if (stop_after_count < 0) {
+    g_print("--stop-after must be greater than 0\n");
+    exit(1);
+  }
+  if (first_only && stop_after_count) {
+    g_print("--stop-after and --first-only are incompatible\n");
+    exit(1);
+  }
+  if (first_only)
+    stop_after_count = 1;
+
   /* Decide on the action to take */
   if (show_version) {
     version();
@@ -143,7 +157,7 @@ int main(int argc, char **argv)
   opts = option_info_new();
   opts->no_download = 0;
   opts->no_mark_read = 0;
-  opts->first_only = first_only;
+  opts->stop_after_count = stop_after_count;
   opts->resume = resume;
   opts->debug = debug;
   opts->reverse = reverse;

--- a/src/castget.c
+++ b/src/castget.c
@@ -53,16 +53,8 @@ static int playlist_add(const gchar *playlist_file, const gchar *media_file);
 
 static gboolean verbose = FALSE;
 static gboolean quiet = FALSE;
-static gboolean first_only = FALSE;
-static gboolean resume = FALSE;
-static gboolean debug = FALSE;
-static gboolean show_progress_bar = FALSE;
-static gboolean show_version = FALSE;
 static gboolean new_only = FALSE;
-static gboolean list = FALSE;
-static gboolean catchup = FALSE;
-static gchar *rcfile = NULL;
-static gchar *filter_regex = NULL;
+static option_info *opts = NULL;
 
 int main(int argc, char **argv)
 {
@@ -76,6 +68,15 @@ int main(int argc, char **argv)
   enclosure_filter *filter = NULL;
   GError *error = NULL;
   GOptionContext *context;
+  static gboolean first_only = FALSE;
+  static gboolean resume = FALSE;
+  static gboolean debug = FALSE;
+  static gboolean show_progress_bar = FALSE;
+  static gchar *rcfile = NULL;
+  static gchar *filter_regex = NULL;
+  static gboolean list = FALSE;
+  static gboolean catchup = FALSE;
+  static gboolean show_version = FALSE;
 
   static GOptionEntry options[] = {
     { "catchup", 'c', 0, G_OPTION_ARG_NONE, &catchup,
@@ -136,14 +137,30 @@ int main(int argc, char **argv)
     exit(0);
   }
 
-  if (catchup)
+  opts = option_info_new();
+  opts->no_download = 0;
+  opts->no_mark_read = 0;
+  opts->first_only = first_only;
+  opts->resume = resume;
+  opts->debug = debug;
+  opts->show_progress_bar = show_progress_bar;
+
+  if (catchup) {
     op = OP_CATCHUP;
+    opts->no_download = 1;
+    opts->no_mark_read = 0;
+  }
 
-  if (list)
+  if (list) {
     op = OP_LIST;
+    opts->no_download = 1;
+    opts->no_mark_read = 1;
+  }
 
+  opts->filter = NULL;
   if (filter_regex) {
     filter = enclosure_filter_new(filter_regex, FALSE);
+    opts->filter = filter;
     g_free(filter_regex);
   }
 
@@ -205,6 +222,8 @@ int main(int argc, char **argv)
 
   if (filter)
     enclosure_filter_free(filter);
+
+  option_info_free(opts);
 
   g_free(rcfile);
 
@@ -394,7 +413,7 @@ static int _process_channel(const gchar *channel_directory, GKeyFile *kf,
 
   c = channel_new(channel_configuration->url, channel_file,
                   channel_configuration->spool_directory,
-                  channel_configuration->filename_pattern, resume);
+                  channel_configuration->filename_pattern, opts->resume);
   g_free(channel_file);
 
   if (!c) {
@@ -415,18 +434,15 @@ static int _process_channel(const gchar *channel_directory, GKeyFile *kf,
 
   switch (op) {
   case OP_UPDATE:
-    channel_update(c, channel_configuration, update_callback, 0, 0, first_only,
-                   resume, filter, debug, show_progress_bar);
+    channel_update(c, channel_configuration, update_callback, opts);
     break;
 
   case OP_CATCHUP:
-    channel_update(c, channel_configuration, catchup_callback, 1, 0, first_only,
-                   0, filter, debug, show_progress_bar);
+    channel_update(c, channel_configuration, catchup_callback, opts);
     break;
 
   case OP_LIST:
-    channel_update(c, channel_configuration, list_callback, 1, 1, first_only, 0,
-                   filter, debug, show_progress_bar);
+    channel_update(c, channel_configuration, list_callback, opts);
     break;
   }
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -343,12 +343,16 @@ int channel_update(channel *c, void *user_data, channel_callback cb,
 
             _cast_channel_save(c, opts->debug);
           }
-
-          /* If we have been instructed to deal only with the first
-             available enclosure, it is time to break out of the loop. */
-          if (opts->stop_after_count && eligible_items_seen >= opts->stop_after_count)
-            break;
         }
+      }
+
+      /* If we have been instructed to only process a certain number of items
+         and we have seen that number, exit the loop */
+      if (opts->stop_after_count) {
+        int check_index = (opts->count_disregards_eligibility) ? index.iteration : eligible_items_seen;
+        if (check_index >= opts->stop_after_count) {
+          break;
+}
       }
     }
   }
@@ -372,6 +376,7 @@ int channel_update(channel *c, void *user_data, channel_callback cb,
 void _initialize_index(channel_index *index, int num_items, int reverse) {
   index->ended = 0;
   index->reverse = reverse;
+  index->iteration = 0;
   if (reverse) {
     index->start = num_items -1;
     index->stop = 0;
@@ -387,6 +392,7 @@ int _next_index(channel_index *index) {
   if (index->ended)
     return 0;
 
+  index->iteration++;
   if (index->reverse) {
     index->current--;
     if (index->current < index->stop) {

--- a/src/channel.c
+++ b/src/channel.c
@@ -298,7 +298,7 @@ static int _do_catchup(channel *c, channel_info *channel_info, rss_item *item,
 int channel_update(channel *c, void *user_data, channel_callback cb,
                        option_info *opts)
 {
-  int i, download_failed;
+  int i, download_failed, eligible_items_seen = 0;
   rss_file *f;
 
   /* Retrieve the RSS file. */
@@ -322,6 +322,7 @@ int channel_update(channel *c, void *user_data, channel_callback cb,
         item = f->items[i];
 
         if (!opts->filter || _enclosure_pattern_match(opts->filter, item->enclosure)) {
+          eligible_items_seen++;
           if (opts->no_download)
             download_failed =
                 _do_catchup(c, &(f->channel_info), item, user_data, cb);
@@ -345,7 +346,7 @@ int channel_update(channel *c, void *user_data, channel_callback cb,
 
           /* If we have been instructed to deal only with the first
              available enclosure, it is time to break out of the loop. */
-          if (opts->first_only)
+          if (opts->stop_after_count && eligible_items_seen >= opts->stop_after_count)
             break;
         }
       }

--- a/src/channel.h
+++ b/src/channel.h
@@ -60,6 +60,7 @@ typedef struct _option_info {
   int no_download;
   int no_mark_read;
   int stop_after_count;
+  int count_disregards_eligibility;
   int reverse;
   int resume;
   enclosure_filter *filter;
@@ -73,6 +74,7 @@ typedef struct _channel_index {
   int reverse;
   int current;
   int ended;
+  int iteration;
 } channel_index;
 
 typedef void (*channel_callback)(void *user_data, channel_action action,

--- a/src/channel.h
+++ b/src/channel.h
@@ -56,6 +56,16 @@ typedef struct _enclosure_filter {
   gboolean caseless;
 } enclosure_filter;
 
+typedef struct _option_info {
+  int no_download;
+  int no_mark_read;
+  int first_only;
+  int resume;
+  enclosure_filter *filter;
+  int debug;
+  int show_progress_bar;
+} option_info;
+
 typedef void (*channel_callback)(void *user_data, channel_action action,
                                  channel_info *channel_info,
                                  enclosure *enclosure, const char *filename);
@@ -65,9 +75,10 @@ channel *channel_new(const char *url, const char *channel_file,
                      int resume);
 void channel_free(channel *c);
 int channel_update(channel *c, void *user_data, channel_callback cb,
-                   int no_download, int no_mark_read, int first_only,
-                   int resume, enclosure_filter *filter, int debug,
-                   int progress_bar);
+                   option_info *opt);
+
+option_info *option_info_new();
+void option_info_free(option_info *e);
 
 enclosure_filter *enclosure_filter_new(const gchar *pattern, gboolean caseless);
 void enclosure_filter_free(enclosure_filter *e);

--- a/src/channel.h
+++ b/src/channel.h
@@ -59,7 +59,7 @@ typedef struct _enclosure_filter {
 typedef struct _option_info {
   int no_download;
   int no_mark_read;
-  int first_only;
+  int stop_after_count;
   int reverse;
   int resume;
   enclosure_filter *filter;

--- a/src/channel.h
+++ b/src/channel.h
@@ -60,11 +60,20 @@ typedef struct _option_info {
   int no_download;
   int no_mark_read;
   int first_only;
+  int reverse;
   int resume;
   enclosure_filter *filter;
   int debug;
   int show_progress_bar;
 } option_info;
+
+typedef struct _channel_index {
+  int start;
+  int stop;
+  int reverse;
+  int current;
+  int ended;
+} channel_index;
 
 typedef void (*channel_callback)(void *user_data, channel_action action,
                                  channel_info *channel_info,


### PR DESCRIPTION
Sorry there are so many changes in this one PR, but they sort of build on each other.

Commits fix #41 and #26.  Provides a solution for #34 but via command line option rather than the requested config option

Although I didn't directly address the root cause, these changes were motivated by #45.  Something happens in the feed such that long-downloaded enclosures suddenly attempt to be downloaded.  Because the file already exists I end up with "Enclosure file FOO already exists".  Because I'm running it in cron, I get alerted about this issue I don't really care about every morning until I manually intervene.

My thinking for a solution to this is "Why am I scanning the entire feed?  To the best of my knowledge all old episodes were successfully downloaded, don't even consider them for processing".  I thought that --first-only would solve this, but as pointed out in #26, that option runs until it finds at least one item eligible for processing, so it doesn't actually work for "only consider the first item in the channel".

To address this and add additional flexibility, I've done the following:

* implement --stop-after and reimplement such that --first-only is just a convenience for --stop-after=1.  By default this behaves as it did before - the count of "seen" items only increments for items that are eligible for processing.
* implement --count-disregards-eligibility.  This changes it so that the count of "seen" items increments for all items, regardless of eligibility
* implement --first-only-disregard-eligibility.  This is equivalent to "--stop-after=1 --count-disregards-eligibility"

After all that, I can now change my cronjob from `/usr/local/bin/castget -q -first-only` to `/usr/local/bin/castget -q --stop-after=3 --count-disregards-eligibility`.  That allows me to consider only the first three items in each feed, regardless of whether they were eligible for processing or not.  This means I can disregard old episodes while also being reasonably sure I am seeing all episodes, even if they post multiple at once.

I still have a small risk of experiencing the issue in #45, but in my experience it tends to happen with older files so the risk is small.

I don't do day to day programming in C, so if I've made obvious mistakes please let me know.

I looked at the tests a little and didn't really understand them.  If you want to accept this PR and lack of tests is holding you up, let me know and I'll look at adding them.

Thanks for castget, it's a great tool.