### PR TITLE
add support for user_agent configuration

### DIFF
--- a/src/castget.c
+++ b/src/castget.c
@@ -394,7 +394,8 @@ static int _process_channel(const gchar *channel_directory, GKeyFile *kf,
 
   c = channel_new(channel_configuration->url, channel_file,
                   channel_configuration->spool_directory,
-                  channel_configuration->filename_pattern, resume);
+                  channel_configuration->filename_pattern, resume,
+                  channel_configuration->user_agent);
   g_free(channel_file);
 
   if (!c) {

--- a/src/channel.h
+++ b/src/channel.h
@@ -36,6 +36,7 @@ typedef struct _channel {
   gchar *filename_pattern;
   GHashTable *downloaded_enclosures;
   gchar *rss_last_fetched;
+  gchar *user_agent;
 } channel;
 
 typedef struct _channel_info {
@@ -62,7 +63,7 @@ typedef void (*channel_callback)(void *user_data, channel_action action,
 
 channel *channel_new(const char *url, const char *channel_file,
                      const char *spool_directory, const char *filename_pattern,
-                     int resume);
+                     int resume, const char *user_agent);
 void channel_free(channel *c);
 int channel_update(channel *c, void *user_data, channel_callback cb,
                    int no_download, int no_mark_read, int first_only,

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -108,6 +108,7 @@ struct channel_configuration *channel_configuration_new(
   c->comment_tag =
       _read_channel_configuration_key(kf, identifier, "comment_tag");
   c->regex_filter = _read_channel_configuration_key(kf, identifier, "filter");
+  c->user_agent = _read_channel_configuration_key(kf, identifier, "user_agent");
 
   /* Populate with defaults if necessary. */
   if (defaults) {
@@ -143,6 +144,9 @@ struct channel_configuration *channel_configuration_new(
 
     if (!c->regex_filter && defaults->regex_filter)
       c->regex_filter = g_strdup(defaults->regex_filter);
+
+    if (!c->user_agent && defaults->user_agent)
+      c->user_agent = g_strdup(defaults->user_agent);
   }
 
   return c;
@@ -198,7 +202,8 @@ int channel_configuration_verify_keys(GKeyFile *kf, const char *identifier)
                !strcmp(key_list[i], "genre_tag") ||
                !strcmp(key_list[i], "year_tag") ||
                !strcmp(key_list[i], "comment_tag") ||
-               !strcmp(key_list[i], "filter"))) {
+               !strcmp(key_list[i], "filter") ||
+               !strcmp(key_list[i], "user_agent"))) {
       fprintf(stderr, "Invalid key %s in configuration of channel %s.\n",
               key_list[i], identifier);
       return -1;

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -35,6 +35,7 @@ struct channel_configuration {
   gchar *year_tag;
   gchar *comment_tag;
   gchar *regex_filter;
+  gchar *user_agent;
 };
 
 struct channel_configuration *channel_configuration_new(

--- a/src/rss.c
+++ b/src/rss.c
@@ -21,6 +21,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include "channel.h"
 #include "htmlent.h"
 #include "libxmlutil.h"
 #include "rss.h"
@@ -252,20 +253,20 @@ rss_file *rss_open_file(const char *filename)
   return f;
 }
 
-static int _rss_open_url_cb(FILE *f, gpointer user_data, int debug)
+static int _rss_open_url_cb(FILE *f, gpointer user_data, int debug, channel *c)
 {
   gchar *url = (gchar *)user_data;
 
-  return urlget_file(url, f, debug);
+  return urlget_file(url, f, debug, c);
 }
 
-rss_file *rss_open_url(const char *url, int debug)
+rss_file *rss_open_url(const char *url, int debug, channel *c)
 {
   rss_file *f;
   gchar *rss_filename;
 
   if (write_by_temporary_file(NULL, _rss_open_url_cb, (gpointer)url,
-                              &rss_filename, debug))
+                              &rss_filename, debug, c))
     return NULL;
 
   f = rss_open_file(rss_filename);

--- a/src/rss.h
+++ b/src/rss.h
@@ -46,7 +46,7 @@ typedef struct _rss_file {
 } rss_file;
 
 rss_file *rss_open_file(const char *filename);
-rss_file *rss_open_url(const char *url, int debug);
+rss_file *rss_open_url(const char *url, int debug, channel *c);
 void rss_close(rss_file *f);
 
 #endif /* RSS_H */

--- a/src/urlget.c
+++ b/src/urlget.c
@@ -29,15 +29,16 @@
 #include <stdlib.h>
 #include <string.h>
 
-int urlget_file(const char *url, FILE *f, int debug)
+int urlget_file(const char *url, FILE *f, int debug, channel *c)
 {
-  return urlget_buffer(url, (void *)f, NULL, 0, debug, NULL);
+  return urlget_buffer(url, (void *)f, NULL, 0, debug, NULL, c);
 }
 
 int urlget_buffer(const char *url, void *user_data,
                   size_t (*write_buffer)(void *buffer, size_t size,
                                          size_t nmemb, void *user_data),
-                  long resume_from, int debug, progress_bar *pb)
+                  long resume_from, int debug, progress_bar *pb,
+                  channel *c)
 {
   CURL *easyhandle;
   CURLcode success;
@@ -46,8 +47,11 @@ int urlget_buffer(const char *url, void *user_data,
   gchar *user_agent;
 
   /* Construct user agent string. */
-  user_agent = g_strdup_printf("%s (%s rss enclosure downloader)",
-                               PACKAGE_STRING, PACKAGE);
+  if (c->user_agent)
+    user_agent = g_strdup(c->user_agent);
+  else
+    user_agent = g_strdup_printf("%s (%s rss enclosure downloader)",
+                                 PACKAGE_STRING, PACKAGE);
 
   /* Initialise curl. */
   easyhandle = curl_easy_init();

--- a/src/urlget.h
+++ b/src/urlget.h
@@ -21,11 +21,13 @@
 #define URLGET_H
 
 #include "progress.h"
+#include "channel.h"
 
-int urlget_file(const char *url, FILE *f, int debug);
+int urlget_file(const char *url, FILE *f, int debug, channel *c);
 int urlget_buffer(const char *url, void *user_data,
                   size_t (*write_buffer)(void *buffer, size_t size,
                                          size_t nmemb, void *user_data),
-                  long resume_from, int debug, progress_bar *pb);
+                  long resume_from, int debug, progress_bar *pb,
+                  channel *c);
 
 #endif /* URLGET_H */

--- a/src/utils.c
+++ b/src/utils.c
@@ -32,9 +32,9 @@
 
 int write_by_temporary_file(const gchar *filename,
                             int (*writer)(FILE *f, gpointer user_data,
-                                          int debug),
+                                          int debug, channel *c),
                             gpointer user_data, gchar **used_filename,
-                            int debug)
+                            int debug, channel *c)
 {
   int retval;
   FILE *f;
@@ -72,7 +72,7 @@ int write_by_temporary_file(const gchar *filename,
     return -1;
   }
 
-  retval = writer(f, user_data, debug);
+  retval = writer(f, user_data, debug, c);
 
   fclose(f);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -20,14 +20,16 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include "channel.h"
+
 #include <glib.h>
 #include <stdio.h>
 
 int write_by_temporary_file(const gchar *filename,
                             int (*writer)(FILE *f, gpointer user_data,
-                                          int debug),
+                                          int debug, channel *c),
                             gpointer user_data, gchar **used_filename,
-                            int debug);
+                            int debug, channel *c);
 gchar *get_rfc822_time(void);
 
 #endif /* UTILS_H */


### PR DESCRIPTION
fixes #31

demo:

client machine:
```
mb 0 /Users/jetmore/Documents/git/castget > cat castgetrc.dev
[test]
url=http://g3.jetmore.net/~jetmore/fake-podcast/feed.xml
spool=/Users/jetmore/Documents/podcasts/test
filename=%(date)-%(title).mp3

[test2]
url=http://g3.jetmore.net/~jetmore/fake-podcast/feed.xml
spool=/Users/jetmore/Documents/podcasts/test2
filename=%(date)-%(title).mp3
user_agent=This is a test user agent
mb 0 /Users/jetmore/Documents/git/castget > date ; ./src/castget -v -1 --rcfile=./castgetrc.dev
Sun Jan 22 00:00:18 EST 2023
Updating channel test...
 * http://g3.jetmore.net/~jetmore/fake-podcast/ep5.mp3 (28 bytes)
Updating channel test2...
 * http://g3.jetmore.net/~jetmore/fake-podcast/ep5.mp3 (28 bytes)
mb 0 /Users/jetmore/Documents/git/castget >
```

server apache logs:
```
jetmore@g3:~/public_html/fake-podcast$ sudo grep "00:00:18" /var/log/apache2/access.log
192.168.0.15 - - [22/Jan/2023:00:00:18 -0500] "GET /~jetmore/fake-podcast/feed.xml HTTP/1.1" 200 1116 "-" "castget 2.0.1 (castget rss enclosure downloader)"
192.168.0.15 - - [22/Jan/2023:00:00:18 -0500] "GET /~jetmore/fake-podcast/ep5.mp3 HTTP/1.1" 200 256 "-" "castget 2.0.1 (castget rss enclosure downloader)"
192.168.0.15 - - [22/Jan/2023:00:00:18 -0500] "GET /~jetmore/fake-podcast/feed.xml HTTP/1.1" 200 1116 "-" "This is a test user agent"
192.168.0.15 - - [22/Jan/2023:00:00:18 -0500] "GET /~jetmore/fake-podcast/ep5.mp3 HTTP/1.1" 200 256 "-" "This is a test user agent"
```